### PR TITLE
Check if parity is running

### DIFF
--- a/electron/index.js
+++ b/electron/index.js
@@ -60,6 +60,11 @@ function createWindow () {
       urls: ['ws://*/*', 'wss://*/*']
     },
     (details, callback) => {
+      if (!mainWindow) {
+        // There might be a split second where the user closes the app, so
+        // mainWindow is null, but there is still a network request done.
+        return;
+      }
       details.requestHeaders.Origin = `parity://${mainWindow.id}.ui.parity`;
       callback({ requestHeaders: details.requestHeaders }); // eslint-disable-line
     }

--- a/electron/operations/isParityRunning.js
+++ b/electron/operations/isParityRunning.js
@@ -6,7 +6,7 @@
 const axios = require('axios');
 const retry = require('async-retry');
 
-const cli = require('../cli');
+const { cli } = require('../cli');
 const pino = require('../utils/pino')();
 
 // Try to ping these hosts
@@ -29,11 +29,10 @@ const isParityRunning = async () => {
     // Retry to ping as many times as there are hosts in `hostsToPing`
     await retry(
       async (_, attempt) => {
-        await axios.get(hostsToPing[attempt - 1]);
+        const host = hostsToPing[attempt - 1]; // Attempt starts with 1
+        await axios.get(host);
         pino.info(
-          `Another instance of parity is already running on ${hostsToPing[
-            attempt - 1
-          ]}, skip running local instance.`
+          `Another instance of parity is already running on ${host}, skip running local instance.`
         );
       },
       { retries: hostsToPing.length }

--- a/electron/operations/runParity.js
+++ b/electron/operations/runParity.js
@@ -23,7 +23,7 @@ let parity = null; // Will hold the running parity instance
 // panic). They happen when an instance of parity is already running, and
 // parity-ui tries to launch another one.
 const catchableErrors = [
-  'is already in use, make sure that another instance of an Ethereum client is not running or change the address using the --ws-port and --ws-interface options.',
+  'is already in use, make sure that another instance of an Ethereum client is not running',
   'IO error: While lock file:'
 ];
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "pino": "^4.16.1",
     "pino-multi-stream": "^3.1.2",
     "promise-any": "^0.2.0",
-    "ps-node": "^0.1.6",
     "react": "^16.3.2",
     "react-blockies": "^1.3.0",
     "react-dom": "^16.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2147,10 +2147,6 @@ connect-history-api-fallback@^1.3.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz#b06873934bc5e344fef611a196a6faae0aee015a"
 
-connected-domain@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/connected-domain/-/connected-domain-1.0.0.tgz#bfe77238c74be453a79f0cb6058deeb4f2358e93"
-
 console-browserify@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-browserify/-/console-browserify-1.1.0.tgz#f0241c45730a9fc6323b206dbf38edc741d0bb10"
@@ -7278,12 +7274,6 @@ prr@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
 
-ps-node@^0.1.6:
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/ps-node/-/ps-node-0.1.6.tgz#9af67a99d7b1d0132e51a503099d38a8d2ace2c3"
-  dependencies:
-    table-parser "^0.1.3"
-
 ps-tree@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/ps-tree/-/ps-tree-1.1.0.tgz#b421b24140d6203f1ed3c76996b4427b08e8c014"
@@ -8834,12 +8824,6 @@ symbol-observable@^1.0.2:
 symbol-tree@^3.2.1:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
-
-table-parser@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/table-parser/-/table-parser-0.1.3.tgz#0441cfce16a59481684c27d1b5a67ff15a43c7b0"
-  dependencies:
-    connected-domain "^1.0.0"
 
 table@4.0.2:
   version "4.0.2"


### PR DESCRIPTION
Instead of using `ps-node` and doing a `ps aucx | grep parity` to find out if an instance of parity is already running, we now do something simpler. We just ping:
- `127.0.0.1:8545`
- `127.0.0.1:8546`
- and whatever --ws-port and --ws-interface the user inputs.

If one of them is responding, then we assume there's a parity instance running. This should cover most of the use cases.

The reason why we drop `ps-node` is that there might be another command containing parity in the name (e.g. parity-ui, parity*?) which would create false positives hard to debug.

Also, if there indeed *is* another parity running (on a custom port), then electron will still launch its own parity, but there would be a recognizable error (`lock file in use`, or `...is already in use`); we catch those errors, and silently ignore them.

cc @Tbaut 